### PR TITLE
refactor: improve NativeViewContainer API & fix: window restore animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.0.2
 
+- chore: switch to MIT license.
 - fix: window restore animation after clicking on taskbar icon (@alexmercerind).
 - refactor: plugin initialization (@alexmercerind).
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Add following lines to your `windows/runner/main.cpp` file:
 ```diff
   window.SetQuitOnClose(true);
 
-+ flutternativeview::CreateNativeViewContainer();
++ flutternativeview::NativeViewContainer::GetInstance()->Create();
 
   ::MSG msg;
   while (::GetMessage(&msg, nullptr, 0, 0)) {

--- a/README.md
+++ b/README.md
@@ -155,11 +155,12 @@ controller.dispose();
 - Windows 10 & higher support.
 - Proper disposing of `HWND` and instances.
 - Semi transparent `Widget`s on top of `NativeView`.
-- Customizable hit-test i.e. optional interactability with the `NativeView`s.
 - Placement of `NativeView`s inside scrollables like `ListView`s.
+- [UNSTABLE] Customizable hit-test i.e. optional interactability with the `NativeView`s.
 
 #### Under Progress
 
+- Stable support for interactability with the `NativeView`s [maybe switching to programmatic approach].
 - Support for older Windows versions.
 - Defining z-order for each `NativeViewController`.
 - Finalized API.

--- a/core/native_view_container.h
+++ b/core/native_view_container.h
@@ -23,9 +23,32 @@ namespace flutternativeview {
 extern "C" {
 #endif
 
-DLLEXPORT HWND CreateNativeViewContainer();
+class NativeViewContainer {
+ public:
+  DLLEXPORT static NativeViewContainer* GetInstance();
 
-DLLEXPORT HWND GetNativeViewContainer(HWND window);
+  // Creates a new |NativeViewContainer| to hold various native views.
+  // Transitions on this window are disabled using
+  // |DWMWA_TRANSITIONS_FORCEDISABLED|.
+  DLLEXPORT HWND NativeViewContainer::Create();
+
+  // Returns the |NativeViewContainer|'s window handle for the given parent
+  // |window|. The method also removes the taskbar entry of |handle_| & returns
+  // focus back to |window| (if lost).
+  // |window| is stored on |NativeViewContainer|'s window as |GWLP_USERDATA|.
+  DLLEXPORT HWND NativeViewContainer::Get(HWND window);
+
+ private:
+  static std::unique_ptr<NativeViewContainer> NativeViewContainer::instance_;
+  static constexpr auto kClassName = L"FLUTTER_NATIVE_VIEW";
+  static constexpr auto kWindowName = L"flutter_native_view";
+
+  static LRESULT CALLBACK NativeViewContainer::WindowProc(
+      HWND const window, UINT const message, WPARAM const wparam,
+      LPARAM const lparam) noexcept;
+
+  HWND handle_;
+};
 
 #ifdef __cplusplus
 }

--- a/core/native_view_core.cc
+++ b/core/native_view_core.cc
@@ -27,7 +27,8 @@ NativeViewCore::NativeViewCore(HWND window, HWND child_window)
 
 void NativeViewCore::EnsureInitialized() {
   flutternativeview::SetWindowComposition(window_, 6, 0);
-  native_view_container_ = flutternativeview::GetNativeViewContainer(window_);
+  native_view_container_ =
+      flutternativeview::NativeViewContainer::GetInstance()->Get(window_);
 }
 
 void NativeViewCore::CreateNativeView(HWND native_view, RECT rect,
@@ -101,13 +102,15 @@ std::optional<HRESULT> NativeViewCore::WindowProc(HWND hwnd, UINT message,
     case WM_SIZE: {
       // Keeping the |native_view_container_| hidden when minimizing the app &
       // showing it again only when the app is restored.
-      if (last_wm_size_wparam_ == SIZE_MINIMIZED) {
-        std::thread([=]() {
-          std::this_thread::sleep_for(
-              std::chrono::milliseconds(kNativeViewPositionAndShowDelay));
-          ::ShowWindow(native_view_container_, SW_SHOWNOACTIVATE);
-        }).detach();
-      }
+      // ---- INTENTIONALLY COMMENTED OUT ----
+      // if (last_wm_size_wparam_ == SIZE_MINIMIZED) {
+      //   std::thread([=]() {
+      //     std::this_thread::sleep_for(
+      //         std::chrono::milliseconds(kNativeViewPositionAndShowDelay));
+      //     ::ShowWindow(native_view_container_, SW_SHOWNOACTIVATE);
+      //   }).detach();
+      // }
+
       // Handle Windows's minimize & maximize animations properly.
       // Since |SetWindowPos| & other Win32 APIs on |native_view_container_|
       // do not re-produce the same DWM animations like  actual user

--- a/example/windows/runner/main.cpp
+++ b/example/windows/runner/main.cpp
@@ -32,7 +32,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   }
   window.SetQuitOnClose(true);
 
-  flutternativeview::CreateNativeViewContainer();
+  flutternativeview::NativeViewContainer::GetInstance()->Create();
 
   ::MSG msg;
   while (::GetMessage(&msg, nullptr, 0, 0)) {


### PR DESCRIPTION
- refactor: improve NativeViewContainer API
A more consistent object-oriented approach compared to existing code.
- fix: window restore animation
Due to some reason, the underlying `flutter_native_view` window used to show up early (before actual `window`) when clicking the taskbar icon (after minimizing) to re-store the window. It made it obvious like the content is being rendered on a second window. 
Now experience is very seamless as compared to before.
