### PR TITLE
Add method to hide window decorations for full screen

### DIFF
--- a/core/native_view_container.cc
+++ b/core/native_view_container.cc
@@ -62,6 +62,19 @@ HWND NativeViewContainer::Get(HWND window) {
   return handle_;
 }
 
+void NativeViewContainer::SetFullScreen(bool full_screen) {
+  if (full_screen) {
+    SetWindowLongPtr(
+        handle_, GWL_STYLE,
+        GetWindowLong(handle_, GWL_STYLE) & ~(WS_CAPTION | WS_THICKFRAME));
+
+  } else {
+    SetWindowLongPtr(
+        handle_, GWL_STYLE,
+        GetWindowLong(handle_, GWL_STYLE) | WS_CAPTION | WS_THICKFRAME);
+  }
+}
+
 LRESULT CALLBACK NativeViewContainer::WindowProc(HWND const window,
                                                  UINT const message,
                                                  WPARAM const wparam,

--- a/core/native_view_container.h
+++ b/core/native_view_container.h
@@ -38,6 +38,10 @@ class NativeViewContainer {
   // |window| is stored on |NativeViewContainer|'s window as |GWLP_USERDATA|.
   DLLEXPORT HWND NativeViewContainer::Get(HWND window);
 
+  // Adds/removes window decorations from the |NativeViewContainer| for use in
+  // full screen mode.
+  DLLEXPORT void SetFullScreen(bool full_screen);
+
  private:
   static std::unique_ptr<NativeViewContainer> NativeViewContainer::instance_;
   static constexpr auto kClassName = L"FLUTTER_NATIVE_VIEW";

--- a/lib/src/flutter_native_view.dart
+++ b/lib/src/flutter_native_view.dart
@@ -8,10 +8,17 @@ import 'package:flutter/services.dart';
 import 'package:flutter_native_view/src/ffi.dart';
 import 'package:flutter_native_view/src/constants.dart';
 
+const _channel = MethodChannel(kMethodChannelName);
+
 class FlutterNativeView {
   static Future<void> ensureInitialized() async {
-    await const MethodChannel(kMethodChannelName).invokeMethod('');
+    await _channel.invokeMethod('init');
     FFI.ensureInitialized();
     FFI.nativeViewCoreEnsureInitialized();
+  }
+
+  static Future<void> setFullScreen(bool isFullScreen) async {
+    await _channel
+        .invokeMethod('setFullScreen', {'isFullScreen': isFullScreen});
   }
 }


### PR DESCRIPTION
This PR adds a method to toggle the container window's border and title bar. This can be used in conjunction with something like [window_manager](https://pub.dev/packages/window_manager) to implement full screen.

Fixes #19 